### PR TITLE
Implement EM and gradient loop except for gradient calculation

### DIFF
--- a/src/argmaxQ.m
+++ b/src/argmaxQ.m
@@ -1,0 +1,67 @@
+function [alpha_est_new,rho_est_new,sigma_rho_est_new] = ...
+                                                argmaxQ(alpha_est,...
+                                                        rho_est,...
+                                                        sigma_rho_est, ...
+                                                        P, ...
+                                                        learning_rate,...
+                                                        max_iterations, ...
+                                                        tol)
+% Calculates the values for alpha_tilde, rho_tilde and sigma_rho_tilde
+% that maximize Q(alpha_tilde, rho_tilde, sigma_rho_tilde | alpha_est,
+% rho_est, and sigma_rho_est, where Q is defined in the paper. 
+%
+% alpha_est: a r-dimensional vector of mixing probabilities
+% rho_est: a cell array of L cells, where rho_est{l} is a 
+%          vector of length k(k-1)/2. (A vectorized correlation matrix)
+% sigma_rho_est: a cell array of L cells, where sigma_est{l} is a 
+%             (k(k-1)/2) x (k(k-1)/2) covariance matrix.
+%
+% Projected gradient descent will be used to ensure that rho_tilde remains  
+% a vectorization of a valid correlation matrix
+
+% Step 1: Initialize the tilde variables (variables being optimized over)
+
+L = length(rho_est);
+r = length(alpha_est);
+len_rho = length(rho_est{1}); % = k(k-1)/2
+
+alpha_tilde = alpha_est;  % Initialize to current estimates
+rho_tilde = rho_est;
+sigma_rho_tilde = sigma_rho_est;
+
+iteration = 1;
+norm_grad = Inf;
+% Step 2: Loop until max_iterations or ||gradient|| < tol
+while iteration < max_iterations & norm_grad >= tol
+    iteration = iteration + 1;
+
+    % Step 2.1: Compute derivative of Q for optimization (tilde) variables
+                gradient_alpha_tilde = zeros(1,r); % r vector
+                gradient_rho_tilde = cell(1,L); % k(k-1)/2-vector for each 
+                                                % cell l
+                for l = 1:L
+                    gradient_rho_tilde{l} = zeros(len_rho,1);
+                end
+    % Step 2.2: Apply the gradient step to optimization (tilde) variables
+                alpha_tilde = alpha_tilde - ...
+                             learning_rate*gradient_alpha_tilde;
+                for l=1:L
+                    rho_tilde{l} = rho_tilde{l} - ...
+                                   learning_rate*gradient_rho_tilde{l};
+                end
+    % Step 2.3: Apply the correlation projection to rho_tilde. Will need
+    %           to convert to matrix form, apply projection, and convert
+    %           back to vector form. 
+                for l=1:L
+                    matrix_rho_tilde = vecLInverse(rho_tilde{l});
+                    matrix_rho_tilde = ensureValidNearCorrInput(...
+                                            matrix_rho_tilde,.01);
+                    matrix_rho_tilde = nearcorr(matrix_rho_tilde);
+                    rho_tilde{l} = vecL(matrix_rho_tilde);
+                end
+end
+alpha_est_new = alpha_tilde;
+rho_est_new = rho_tilde;
+sigma_rho_est_new = sigma_rho_tilde;
+
+end

--- a/src/ensureValidNearCorrInput.m
+++ b/src/ensureValidNearCorrInput.m
@@ -1,0 +1,18 @@
+function out = ensureValidNearCorrInput(inputMatrix,tol)
+    % This returns a matrix that is made from the input but
+    % is ready to be ingested by the nearcorr function
+    % This means clipping all entries to be in the range [-1,1]
+    % and ensuring the matrix is symmetric with diagonal 1.
+    % We hope these violations are small, and if not we should 
+    % trigger a warning. 
+    matrix = inputMatrix;
+    k = length(matrix);
+    matrix = matrix - diag(diag(matrix)) + eye(k);
+    matrix((matrix >= 1) & ~eye(k)) = 1-1e-8; 
+    matrix((matrix <= -1) & ~eye(k)) = -1+1e-8;
+    out = matrix;
+    if max(abs(out-inputMatrix),[],'all')>tol
+        warning(...
+            "inputMatrix is not close enough to a valid nearcorr input")
+    end
+end

--- a/src/randomCorrelationMatrix.m
+++ b/src/randomCorrelationMatrix.m
@@ -1,6 +1,11 @@
 function out = randomCorrelationMatrix(sz)
-    % size sz
-    % out = a random correlation matrix of size sz x sz
+    % Generate a random correlation matrix for initializing 
+    % simulations. This is to make sure the correlation matrix
+    % chosen is arbitrary. 
+    %
+    % sz: height and width of desired matrix
+    %
+    % out: a random correlation matrix of size sz x sz
     A = randn(sz, sz);
     S = A' * A;
     d = sqrt(diag(S)); 

--- a/src/vecL.m
+++ b/src/vecL.m
@@ -1,3 +1,5 @@
 function out = vecL(mat)
+    % Get the vectorized (flattened) part of the matrix strictly below
+    % the diagonal. 
     out = mat(tril(true(size(mat)),-1));
 end

--- a/src/vecLInverse.m
+++ b/src/vecLInverse.m
@@ -1,4 +1,6 @@
 function out = vecLInverse(v)
+    % Get the symmetric matrix formed by placing v in the lower triangular
+    % part and filling the diagonal with ones.
     d = floor((1+sqrt(1+8*length(v)))/2); % Pos. solution of x = d(d-1)/2
     out = zeros(d,d);
     out(tril(true(d,d),-1))=v;


### PR DESCRIPTION
- Add a EM loop that updates the parameters according to a Q(.|.) maximizer function, to be defined
- Define most of Q(.|.) = argmaxQ, leaving only boilerplate code for the gradient calculation itself
- Added the utility function ensureValidNearCorrInput for checking the constraints for nearcorr inputs
- Improved documentation in all functions